### PR TITLE
updated the value for 'com.google.android.gms.version'

### DIFF
--- a/Test/templates/default/android/template/AndroidManifest.xml
+++ b/Test/templates/default/android/template/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		
 		<!-- GameThrive -->
 		<meta-data android:name="com.google.android.gms.version"
-			android:value="6587000"/>
+			android:value="7895000"/>
 		
 		<activity android:name="com.gamethrive.NotificationOpenedActivity"/>
         <receiver

--- a/dependencies/android/AndroidManifest.xml
+++ b/dependencies/android/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		
 		<!-- GameThrive -->
 		<meta-data android:name="com.google.android.gms.version"
-			android:value="6587000"/>
+			android:value="7895000"/>
 		
 		<activity android:name="com.gamethrive.NotificationOpenedActivity"/>
         <receiver


### PR DESCRIPTION
This PR is to fix the following error that I got when trying out the example app under the Test folder:

> error: 
> 
> <pre>
> The meta-data tag in your app's AndroidManifest.xml does not have the right value.  Expected 7895000 but found 6587000. 
> </pre>
> 
> 
> Here is the full backtrace:
> 
> <pre>
> 12-08 21:22:40.170  9993  9993 E GooglePlayServicesUtil: The Google Play services resources were not found. Check your project configuration to ensure that the resources are included.
> 12-08 21:22:40.172  9993  9993 E GameThrive: Could not register with GCM due to an error with the AndroidManifest.xml file or with 'Google Play services'.
> 12-08 21:22:40.172  9993  9993 E GameThrive: java.lang.IllegalStateException: The meta-data tag in your app's AndroidManifest.xml does not have the right value.  Expected 7895000 but found 6587000.  You must have the following declaration within the <application> element:     <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at com.google.android.gms.common.GooglePlayServicesUtil.zzad(Unknown Source)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at com.google.android.gms.common.GooglePlayServicesUtil.isGooglePlayServicesAvailable(Unknown Source)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at com.gamethrive.PushRegistratorGPS.checkPlayServices(PushRegistratorGPS.java:87)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at com.gamethrive.PushRegistratorGPS.registerForPush(PushRegistratorGPS.java:62)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at com.gamethrive.GameThrive.<init>(GameThrive.java:136)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at gamethrive.GameThriveLib$2.run(GameThriveLib.java:86)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at android.os.Handler.handleCallback(Handler.java:739)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at android.os.Handler.dispatchMessage(Handler.java:95)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at android.os.Looper.loop(Looper.java:148)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at android.app.ActivityThread.main(ActivityThread.java:5417)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at java.lang.reflect.Method.invoke(Native Method)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
> 12-08 21:22:40.172  9993  9993 E GameThrive:  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
> 12-08 21:22:40.177  9993 10222 E GooglePlayServicesUtil: The Google Play services resources were not found. Check your project configuration to ensure that the resources are included.
> </pre>
